### PR TITLE
Fix MySQL access denied error in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,17 @@ jobs:
     - name: Start MySQL service
       run: sudo service mysql start
 
+    - name: Set MySQL root user password
+      run: |
+        sudo mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH 'mysql_native_password' BY '${{ secrets.MYSQL_ROOT_PASSWORD }}';"
+        sudo mysql -e "FLUSH PRIVILEGES;"
+
     - name: Create test database and user
       run: |
-        sudo mysql -e "CREATE DATABASE IF NOT EXISTS test_db;"
-        sudo mysql -e "CREATE USER IF NOT EXISTS 'test_user'@'localhost' IDENTIFIED BY 'test_password';"
-        sudo mysql -e "GRANT ALL PRIVILEGES ON test_db.* TO 'test_user'@'localhost';"
-        sudo mysql -e "FLUSH PRIVILEGES;"
+        sudo mysql -u root -p${{ secrets.MYSQL_ROOT_PASSWORD }} -e "CREATE DATABASE IF NOT EXISTS test_db;"
+        sudo mysql -u root -p${{ secrets.MYSQL_ROOT_PASSWORD }} -e "CREATE USER IF NOT EXISTS 'test_user'@'localhost' IDENTIFIED BY 'test_password';"
+        sudo mysql -u root -p${{ secrets.MYSQL_ROOT_PASSWORD }} -e "GRANT ALL PRIVILEGES ON test_db.* TO 'test_user'@'localhost';"
+        sudo mysql -u root -p${{ secrets.MYSQL_ROOT_PASSWORD }} -e "FLUSH PRIVILEGES;"
 
     - name: Run API
       run: npm start
@@ -45,3 +50,4 @@ jobs:
         DATABASE_PASSWORD: test_password
         DATABASE_NAME: test_db
         API_PORT: 5055
+        MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,12 @@ DATABASE_PASSWORD=mysecretpwd
 DATABASE_NAME=myawsomeshop
 
 API_PORT=5055
+MYSQL_ROOT_PASSWORD=rootpassword
 ```
+
+## MySQL Root User Password Configuration
+
+To avoid the "Access denied for user 'root'@'localhost' (using password: NO)" error, you need to set the MySQL root user password in the GitHub Actions workflow. This can be done by adding a step to set the MySQL root user password and updating the MySQL commands to use the root user password.
 
 ## GitHub Actions Workflow
 


### PR DESCRIPTION
Add MySQL root user password configuration to avoid access denied error.

* **readme.md**
  - Add `MYSQL_ROOT_PASSWORD` to the sample ENV file.
  - Add a section explaining the MySQL root user password configuration.

* **.github/workflows/main.yml**
  - Add a step to set the MySQL root user password.
  - Update MySQL commands to use the root user password when creating the test database and user.
  - Add `MYSQL_ROOT_PASSWORD` to the environment variables for the API run step.

